### PR TITLE
Config Mail Catcher

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,15 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    address: 'localhost',
+    port: 1025
+  }
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.


### PR DESCRIPTION
Mailcatcher, which is a simplistic SMTP server that aims to take the SMTP requests it receives and display them in a web interface. It is very interesting so that we can see the email sending that is being done in the development environment.
Additionally, we will configure Rails to use Mailtcher in development.

1- Before we install Mailcatcher, we will need to install some support tools.

[Run in terminal]
If you are on distros derived from Debian

`sudo apt install build-essential`

If you are on distros derived from RedHat

`sudo yum groupinstall 'Development Tools'`

2- After that, we will install SQLite3 and the support tool to access it.
[Run in terminal]
In Debian-derived apts distro
```
sudo apt install libsqlite3-dev
sudo apt install sqlite3
```

On ReadHat-derived distros
```
sudo yum install libsqlite3-devel
sudo yum install sqlite3
```

3- Mailcatcher must be installed separately from our app, so we will not add it to the Gemfile.

[Run in terminal]
`gem install mailcatcher`

4- With it installed, we go to the development settings of our app to configure email sending via SMTP.

[Add the following content to config/environments/development.rb]
```
config.action_mailer.raise_delivery_errors = false

config.action_mailer.default_url_options = { host: "http://localhost:3000" }

config.action_mailer.delivery_method = :smtp

config.action_mailer.smtp_settings = {
 address: 'localhost',
 port: 1025,
}
```

The default_url_options option informs the base URL that will be used in routes that are called from an email view. We are setting the API host by default because just because an API does not have view routes, there may be routes that do not render a view, but send a file, for example. The routes that are necessary to be sent by the front-end will be used by route helpers.
The other two are to inform you that we will use the delivery method via SMTP and the settings to send to Mailcatcher

5- To test if everything is working, let's start by starting Mailcatcher

[Run in terminal]
`mailcatcher`

It will start Mailcatcher with two endpoints: one on port 1025 for the SMTP that we configured above and another on port 1080 to access a web page where we can see the emails that have been sent.

6- Now let's open the browser at http://localhost:1080.
It will open an empty Mailcatcher page

7- Now let's go to the Rails console to send from there

[Run in terminal]
`rails c`

8- Now in the console, we will use ActionMailer to send a test.

[Run in rails console]
```
ActionMailer::Base.mail(to: "test@test.com", from: "anyone@test.com", subject: "Test sending", body: "Test content").deliver_now!
```

9- Now go to the Mailcatcher page in the browser and see that the email we sent is there. And this confirms that we have correctly configured Rails to work with Mailcatcher